### PR TITLE
Replace testCompile with testImplementation

### DIFF
--- a/ratpack-kotlin-gradle/src/main/kotlin/ratpack/kotlin/gradle/RatpackKotlinPlugin.kt
+++ b/ratpack-kotlin-gradle/src/main/kotlin/ratpack/kotlin/gradle/RatpackKotlinPlugin.kt
@@ -34,7 +34,7 @@ class RatpackKotlinPlugin : Plugin<Project> {
       dependencies.add("runtimeOnly", ratpackKotlinExtension.getCompiler())
       dependencies.add("runtimeOnly", ratpackKotlinExtension.getScriptingCompiler())
       dependencies.add("runtimeOnly", ratpackKotlinExtension.getScript())
-      dependencies.add("testCompile", ratpackKotlinExtension.getTest())
+      dependencies.add("testImplementation", ratpackKotlinExtension.getTest())
     }
 
   }


### PR DESCRIPTION
Replaced `testCompile` with `testImplementation`. This is required for compatibility with Gradle 7, as Gradle 7 [removes](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal) the `compile` and `runtime` configurations, which includes `testCompile`. For Gradle 7 projects that depend on the `ratpack-kotlin` plugin, the following build failure is shown:

```
An exception occurred applying plugin request [id: 'me.drmaas.ratpack-kotlin', version: '1.10.2']
> Failed to apply plugin 'me.drmaas.ratpack-kotlin'.
   > Configuration with name 'testCompile' not found.
```